### PR TITLE
Strip whitespaces from token in setup

### DIFF
--- a/trellosa/command/setup.py
+++ b/trellosa/command/setup.py
@@ -59,7 +59,7 @@ class SetupMode(BaseCommand):
             url = generate_token_url(tr)
             logger.info("Go to `%s`, authorize a token, and give it to me" % url)
             while True:
-                token_candidate = raw_input("Token: ")
+                token_candidate = raw_input("Token: ").strip()
                 if is_valid_token(tr, token_candidate):
                     write_token(token_candidate, self.args.workdir)
                     return 0


### PR DESCRIPTION
Trello's website spits out a token prefixed with a whitespace. This patch strips it out to make copy/paste easier.